### PR TITLE
Change schedule to run vocab update daily

### DIFF
--- a/.github/workflows/update_term_vocab_files.yaml
+++ b/.github/workflows/update_term_vocab_files.yaml
@@ -2,8 +2,8 @@ name: Update standardized term vocab files for community configs
 
 on:
   schedule:
-    # Run once a week on Monday at 8 AM EST in winter, 9 AM EDT in summer
-    - cron: '0 13 * * 1'
+    # Run once a day at 8 AM EST in winter, 9 AM EDT in summer
+    - cron: '0 13 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #64 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Community assessment vocabulary JSON files will now be synced with the corresponding source GSheets once a day

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
