### PR TITLE
[FIX] Ensure existing vocab files can be overwritten during vocab file update

### DIFF
--- a/.github/workflows/update_term_vocab_files.yaml
+++ b/.github/workflows/update_term_vocab_files.yaml
@@ -85,34 +85,16 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
 
-      # TODO: Restore this step once https://github.com/actions/download-artifact/issues/426
-      # and https://github.com/actions/download-artifact/issues/455 are resolved to handle the single-artifact edge case
-      # - name: Download all artifacts
-      #   uses: actions/download-artifact@v8
-      #   with:
-      #     path: configs
-
-      # We manually download artifacts in a loop rather than using the download-artifact action 
-      # to avoid the single-artifact edge case, which can happen if only one community is available
-      # OR only one succeeds the update-terms job due to transient Google Sheets API/Google backend errors (e.g., 503).
-      # 
-      # Because actions/download-artifact does not create a named subdirectory for a single artifact
-      # (https://github.com/actions/download-artifact/issues/426), when this happens due to intermittent API errors, 
-      # there is no easy way to recover the community name corresponding to the generated vocab files using the action.
-      - name: Manually download artifacts into correct community subdirectories
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          community_names='${{ needs.define-matrix.outputs.community_names }}'
-
-          # NOTE: This may break if community names have spaces, but we don't recommend that anyways
-          for community_name in $(echo "$community_names" | jq -r '.[]'); do
-            echo "Downloading artifact $community_name into configs/$community_name"
-            if ! gh run download ${{ github.run_id }} --name "$community_name" --dir "configs/$community_name"; then
-              echo "WARNING: artifact $community_name not found (update-terms may have failed). Skipping."
-              continue
-            fi
-          done
+      # WARNING: If only 1 community succeeds the update-terms job (e.g., due to a transient Google API error),
+      # meaning there is only 1 artifact, this step will download the community config files directly into configs/
+      # because download-artifact doesn't create a named subdirectory for a single artifact.
+      # (see https://github.com/actions/download-artifact/issues/426 
+      # and https://github.com/actions/download-artifact/issues/455).
+      # This should happen rarely since create_term_vocab_from_gsheet.py has retry logic.
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: configs
 
       - name: Get Neurobagel Bot App User ID
         id: get-user-id

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,9 @@ repos:
     hooks:
       - id: flake8
         language_version: python3
+        args:
+          - --extend-ignore=E501
+          - --extend-select=B950
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/code/create_term_vocab_from_gsheet.py
+++ b/code/create_term_vocab_from_gsheet.py
@@ -67,7 +67,7 @@ def load_community_terms_manifest(community_config_dir: Path) -> dict:
 
 
 def fetch_gsheet_to_df(
-    gsheet_id: str, max_retries: int = 3, retry_sleep_s: float = 2
+    gsheet_id: str, max_retries: int = 5, retry_sleep_s: float = 2
 ) -> pd.DataFrame:
     """Access and open a public Google spreadsheet by its ID (found in the spreadsheet URL after /d/)."""
     last_err = None


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Fixes #84 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Revert to using `actions/download-artifact` now that we have >1 community and retry logic for GSheet parsing
- Restore flake8 pre-commit config removed in https://github.com/neurobagel/communities/pull/71 refactor (it was probably unintentionally removed entirely since pyproject.toml doesn't support flake8 config)

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
